### PR TITLE
docs(readme): replace placeholder top-level README with real one

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
 
 [![CI](https://github.com/ovsds/speech-to-text-bot/workflows/Check%20PR/badge.svg)](https://github.com/ovsds/speech-to-text-bot/actions?query=workflow%3A%22%22Check+PR%22%22)
 
-Speech To Text Bot
+Telegram bot that transcribes voice messages and audio/video attachments to text.
 
-## Usage
+## Architecture
+
+Telegram delivers voice and media messages (via webhook or long-polling) to an aiohttp server, where an aiogram dispatcher routes them to a media handler. In the default mode, the handler uploads the audio to S3-compatible storage and starts a [Temporal](https://temporal.io/) workflow that splits the audio on silence, recognizes each chunk in parallel as separate activities, calls back into the bot with the transcript, and cleans up the stored audio. Recognition uses the [`SpeechRecognition`](https://github.com/Uberi/speech_recognition) Python library's Google backend, configured for Russian. A simpler synchronous handler that skips Temporal and S3 is also available for single-process deployments. The two processes — the web/bot server (`backend/bin/main`) and the Temporal worker (`backend/bin/temporalio_worker`) — share the same `backend/lib` codebase.
+
+See [`backend/README.md`](backend/README.md) for the full settings reference.
+
+## Status
+
+Working but maintained for personal use only, not as a service for others.
 
 ## Development
 


### PR DESCRIPTION
**Why:** Top-level README was a one-line placeholder; replace it with a real one so a profile-skimmer can see what the bot does and how it's built without diving into `backend/`.

**Changes:**
- Add a one-line tagline and an Architecture paragraph (Telegram → aiohttp/aiogram → Temporal workflow split/recognize/callback/cleanup → `SpeechRecognition` Google backend; synchronous fallback noted).
- Point to `backend/README.md` for the settings reference instead of duplicating it.
- Add a one-line Status note that the bot is maintained for personal use only.
- Preserve the existing Development section and license footer.

**Notes:** `backend/README.md` and code untouched. Architecture paragraph was written from `backend/lib/app/app.py`, `backend/lib/temporal/{workflows,activities}.py`, `backend/lib/voice/services/recognition_task.py`, and `backend/lib/voice/clients/recognition/speech_recognition.py` — not invented.